### PR TITLE
Initial scaffold for probability-tilt-toolkit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+dist/
+build/
+.ipynb_checkpoints/
+.venv/
+.env/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# probability-tilt-toolkit
-Mini‑games and simulators that exploit eliminative information to tilt probabilities.
+# Probability-Tilt Toolkit
+
+Mini-games and simulations that show how eliminating known losers (à la Monty Hall) reshapes winning odds.  
+Flagship module: **Monty-Stack** – an N-door simulator scalable to 100s/1000s of doors with optional quantum backend.
+
+License: **The Unlicense** (public domain).
+
+## Quick Start
+```bash
+pip install -e .
+python examples/cli_demo.py
+```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,8 @@
+# Roadmap / TODO
+
+- Telegram/Discord bot interface (click → python-telegram-bot / discord.py)
+- Streamlit or HF Spaces web demo
+- Card-count "compression" simulator
+- Bayesian test-elimination demo (medical or bug-hunt theme)
+- Kelly-fraction bankroll module
+- Quantum-Monty notebook: 20 000-shot run, compare drift vs. 1/3–2/3 theory

--- a/examples/cli_demo.py
+++ b/examples/cli_demo.py
@@ -1,0 +1,15 @@
+import click
+from probability_tilt_toolkit.monty import MontyGame
+
+@click.command()
+@click.option("--doors", "-n", default=3, show_default=True)
+def play(doors):
+    game = MontyGame(doors)
+    choice = click.prompt(f"Pick a door 0-{doors-1}", type=int)
+    revealed = game.first_pick(choice)
+    click.echo(f"Goat doors opened: {revealed}")
+    win = game.switch() if click.confirm("Switch?") else game.stick()
+    click.echo("You WIN!" if win else "You lose.")
+
+if __name__ == "__main__":
+    play()

--- a/examples/quantum_monty.ipynb
+++ b/examples/quantum_monty.ipynb
@@ -1,0 +1,36 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Quantum Monty Stub",
+    "\n",
+    "Setup a 3-door Monty Hall circuit using Qiskit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qiskit import QuantumCircuit\n",
+    "qc = QuantumCircuit(3)  # placeholder circuit"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/empirical_vs_theory.ipynb
+++ b/notebooks/empirical_vs_theory.ipynb
@@ -1,0 +1,39 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Empirical vs. Theory",
+    "\n",
+    "Plot switch/stick win rates." 
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "from probability_tilt_toolkit import summary_df\n",
+    "df = summary_df()\n",
+    "df.pivot('n_doors', 'strategy', 'win_rate').plot.bar()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/probability_tilt_toolkit/__init__.py
+++ b/probability_tilt_toolkit/__init__.py
@@ -1,0 +1,4 @@
+from .monty import MontyGame
+from .stats import run_trials, summary_df
+
+__all__ = ["MontyGame", "run_trials", "summary_df"]

--- a/probability_tilt_toolkit/monty.py
+++ b/probability_tilt_toolkit/monty.py
@@ -1,0 +1,34 @@
+import random
+from typing import List
+
+class MontyGame:
+    """Generic N-door Monty Hall simulator."""
+
+    def __init__(self, n_doors: int = 3):
+        if n_doors < 3:
+            raise ValueError("n_doors must be \u2265 3")
+        self.n = n_doors
+        self.reset()
+
+    def reset(self):
+        self.prize = random.randrange(self.n)
+        self.player_choice = None
+        self.revealed: List[int] = []
+
+    def _host_reveal(self):
+        choices = [d for d in range(self.n)
+                   if d != self.player_choice and d != self.prize]
+        self.revealed = random.sample(choices, self.n - 2)
+
+    def first_pick(self, door: int):
+        self.player_choice = door
+        self._host_reveal()
+        return self.revealed
+
+    def stick(self) -> bool:
+        return self.player_choice == self.prize
+
+    def switch(self) -> bool:
+        remaining = [d for d in range(self.n)
+                     if d not in self.revealed and d != self.player_choice][0]
+        return remaining == self.prize

--- a/probability_tilt_toolkit/stats.py
+++ b/probability_tilt_toolkit/stats.py
@@ -1,0 +1,22 @@
+import pandas as pd
+from .monty import MontyGame
+from typing import Literal
+
+def run_trials(n_trials: int = 10000, n_doors: int = 3,
+               strategy: Literal["stick", "switch"] = "switch"):
+    wins = 0
+    game = MontyGame(n_doors)
+    for _ in range(n_trials):
+        game.reset()
+        game.first_pick(0)           # arbitrary first door
+        wins += game.switch() if strategy == "switch" else game.stick()
+    return wins / n_trials
+
+def summary_df(n_doors_list=(3, 10, 50, 100), trials=10000):
+    rows = []
+    for n in n_doors_list:
+        for strat in ("stick", "switch"):
+            rows.append(dict(n_doors=n,
+                             strategy=strat,
+                             win_rate=run_trials(trials, n, strat)))
+    return pd.DataFrame(rows)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "probability-tilt-toolkit"
+version = "0.0.1"
+description = "Tools and simulators for exploiting eliminative probability edges."
+authors = [{name = "Quantum Hobo & Korah", email = "email@example.com"}]
+readme = "README.md"
+requires-python = ">=3.9"
+license = {file = "LICENSE"}
+dependencies = ["numpy", "pandas", "click"]
+
+[project.optional-dependencies]
+quantum = ["qiskit"]
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- add project metadata and package configuration
- implement Monty Hall simulator with analytics
- provide CLI demo and stub notebooks
- document roadmap and usage

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68788b512890832a8ff818ab5fa20ca0