### PR TITLE
Initial probability-tilt toolkit setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,7 @@ quantum = ["qiskit"]
 [build-system]
 requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["probability_tilt_toolkit*"]


### PR DESCRIPTION
## Summary
- add the basic probability-tilt modules and examples
- clarify packaging so editable installs succeed

## Testing
- `pip install -e .`
- `python - <<'EOF'
from probability_tilt_toolkit import run_trials, summary_df
print(run_trials(1000))
print(summary_df(n_doors_list=[3,4], trials=1000))
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68788e4277d4832a8a1ca64b86f480c2